### PR TITLE
Kénitra — Présentation + sections Histoire & Culture (mise en forme + nav interne)

### DIFF
--- a/apps/web/app/[locale]/city/kenitra/kenitra-client.tsx
+++ b/apps/web/app/[locale]/city/kenitra/kenitra-client.tsx
@@ -8,7 +8,7 @@ import { ArrowLeft } from 'lucide-react';
 export default function KenitraPageClient() {
   return (
     <div className="min-h-screen bg-gray-50">
-      <header className="bg-white border-b">
+      <header className="bg-white border-b text-gray-900">
         <div className="container mx-auto px-4 py-6 flex items-center justify-between">
           <h1 className="text-3xl font-bold">Kénitra</h1>
           <Link href="/map">
@@ -20,7 +20,13 @@ export default function KenitraPageClient() {
         </div>
       </header>
 
-      <main className="container mx-auto px-4 py-10 max-w-3xl">
+      <main className="container mx-auto px-4 py-10 max-w-3xl text-gray-900">
+        <nav aria-label="Navigation interne" className="mb-8 flex gap-4 text-sm text-muted-foreground">
+          <a href="#presentation" className="hover:underline">Présentation</a>
+          <a href="#histoire" className="hover:underline">Histoire</a>
+          <a href="#culture" className="hover:underline">Culture</a>
+        </nav>
+
         <section id="presentation" aria-labelledby="presentation-title" className="mb-8">
           <h2 id="presentation-title" className="text-2xl font-semibold mb-3">Présentation</h2>
           <p className="text-base leading-7 text-muted-foreground">
@@ -35,6 +41,37 @@ export default function KenitraPageClient() {
             aux activités de plein air, à la découverte culturelle et aux échanges entre les métropoles
             du littoral atlantique.
           </p>
+        </section>
+
+        <section id="histoire" aria-labelledby="histoire-title" className="mb-12">
+          <h2 id="histoire-title" className="text-2xl font-semibold mb-3">Histoire de Kénitra</h2>
+          <p className="text-base leading-7 text-muted-foreground mb-3">
+            L’essor moderne de Kénitra s’est structuré au XXe siècle autour des axes de transport,
+            de l’activité portuaire et du développement agricole du Gharb. La ville a progressivement
+            diversifié ses fonctions vers l’industrie et l’enseignement supérieur, tout en gardant
+            un lien étroit avec son fleuve et l’océan. Aujourd’hui, Kénitra s’affirme comme un pôle
+            régional connecté, où cohabitent espaces naturels et dynamique urbaine.
+          </p>
+          <ul className="list-disc pl-6 text-base leading-7 text-muted-foreground">
+            <li>Structuration urbaine au XXe siècle</li>
+            <li>Rôle du fleuve Sebou et des infrastructures (rail/autoroute)</li>
+            <li>Ouverture vers l’Atlantique et la station de Mehdia</li>
+          </ul>
+        </section>
+
+        <section id="culture" aria-labelledby="culture-title" className="mb-12">
+          <h2 id="culture-title" className="text-2xl font-semibold mb-3">Culture à Kénitra</h2>
+          <p className="text-base leading-7 text-muted-foreground mb-3">
+            Portée par une population jeune et un réseau associatif actif, la vie culturelle met en
+            valeur les pratiques sportives, les événements locaux et les initiatives étudiantes. La
+            proximité de la Mamora et du littoral favorise les activités de plein air, tandis que
+            l’ancrage académique et la connexion aux grandes villes enrichissent l’offre culturelle.
+          </p>
+          <ul className="list-disc pl-6 text-base leading-7 text-muted-foreground">
+            <li>Vie associative et initiatives étudiantes</li>
+            <li>Plages de Mehdia et forêts de la Mamora</li>
+            <li>Événements locaux et pratiques sportives</li>
+          </ul>
         </section>
       </main>
     </div>

--- a/apps/web/tests/e2e/kenitra.spec.ts
+++ b/apps/web/tests/e2e/kenitra.spec.ts
@@ -52,6 +52,26 @@ test.describe('Carte - Marqueur Kénitra', () => {
     await page.goto('/city/kenitra');
     await expect(page.locator('h1')).toContainText('Kénitra');
   });
+
+  test('Contenu Présentation / Histoire / Culture présent', async ({ page }) => {
+    await page.goto('/city/kenitra');
+
+    // Présentation
+    await expect(page.locator('#presentation')).toBeVisible();
+    await expect(page.locator('text=Présentation')).toBeVisible();
+
+    // Histoire
+    await expect(page.locator('#histoire')).toBeVisible();
+    await expect(page.locator('text=Histoire de Kénitra')).toBeVisible();
+
+    // Culture
+    await expect(page.locator('#culture')).toBeVisible();
+    await expect(page.locator('text=Culture à Kénitra')).toBeVisible();
+
+    // Navigation interne (clic sur ancre)
+    await page.click('a[href="#histoire"]');
+    await expect(page.locator('#histoire')).toBeInViewport();
+  });
 });
 
 


### PR DESCRIPTION
Ajoute le contenu de présentation de Kénitra et structure les sections “Histoire” et “Culture” avec une navigation interne par ancres.
Comment tester
Lancer l’app puis aller sur /city/kenitra
Vérifier que les sections Présentation, Histoire et Culture sont visibles
Cliquer sur “Histoire” dans la nav interne → la section doit être à l’écran
Vérifier que les titres sont lisibles (texte sombre)
Lancer les tests E2E:
cd apps/web && pnpm test:e2e